### PR TITLE
change to use 2.0 of AM API

### DIFF
--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -124,7 +124,7 @@ class QGConnector(api_actions.QGActions):
             url = "https://%s/qps/rest/3.0/" % (self.server,)
         elif api_version == 'am':
             # QualysGuard REST v1 API url (Portal API).
-            url = "https://%s/qps/rest/1.0/" % (self.server,)
+            url = "https://%s/qps/rest/2.0/" % (self.server,)
         else:
             raise Exception("Unknown QualysGuard API Version Number (%s)" % (api_version,))
         logger.debug("Base url =\n%s" % (url))


### PR DESCRIPTION
As 1.0 version seems to be buggy. I tested Qualys AM API extensively for a customer. In summary, when using 1.0 AM API the Qualys returns error when retrieving arbitrary ID range. When the same request is made with 2.0 AM PI all goes well. 

Qualys asked me to do the testing with curl:

Same error happens when I call using curl code: curl -D - -u “username:password" -H "content-type: text/xml" -X "POST" --data-binary @- "https://qualysapi.qg2.apps.qualys.com/qps/rest/1.0/search/am/hostasset" < request.xml

$ bash test_curl.sh 
HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Tue, 09 Jun 2015 06:40:17 GMT

<?xml version="1.0" encoding="UTF-8"?>
<ServiceResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://qualysapi.qg2.apps.qualys.com/qps/xsd/1.0/am/hostasset.xsd">
  <responseCode>OTHER_ERROR</responseCode>
  <responseErrorDetails>
    <errorMessage>An error occurred during request processing. Please contact your account manager.</errorMessage>
  </responseErrorDetails>

When I call using 2.0 API I get the results needed. 

 curl -D - -u “username:password" -H "content-type: text/xml" -X "POST" --data-binary @- "https://qualysapi.qg2.apps.qualys.com/qps/rest/2.0/search/am/hostasset" < request.xml

HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
evaluation: false
Content-Type: application/xml
Transfer-Encoding: chunked
Date: Tue, 09 Jun 2015 06:38:00 GMT

<?xml version="1.0" encoding="UTF-8"?>
<ServiceResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://qualysapi.qg2.apps.qualys.com/qps/xsd/2.0/am/hostasset.xsd">
  <responseCode>SUCCESS</responseCode>
  <count>100</count>
