### PR TITLE
Am2

### DIFF
--- a/qualysapi/api_methods.py
+++ b/qualysapi/api_methods.py
@@ -130,7 +130,7 @@ api_methods['am get'] = set([
     'get/am/tag/',
 ])
 # Asset Management v2 GET methods.
-api_methods['am get'] = set([
+api_methods['am2 get'] = set([
     'get/am/asset/',
     'get/am/hostasset/',
     'get/am/tag/',

--- a/qualysapi/api_methods.py
+++ b/qualysapi/api_methods.py
@@ -129,9 +129,19 @@ api_methods['am get'] = set([
     'get/am/hostasset/',
     'get/am/tag/',
 ])
+# Asset Management v2 GET methods.
+api_methods['am get'] = set([
+    'get/am/asset/',
+    'get/am/hostasset/',
+    'get/am/tag/',
+    'get/am/hostinstancevuln/',
+    'get/am/assetdataconnector/',
+    'get/am/awsassetdataconnector/',
+    'get/am/awsauthrecord/',
+])
 # Keep track of methods with ending slashes to autocorrect user when they forgot slash.
 api_methods_with_trailing_slash = defaultdict(set)
-for method_group in set(['1', '2', 'was', 'am']):
+for method_group in set(['1', '2', 'was', 'am','am2']):
     for method in api_methods[method_group]:
         if method[-1] == '/':
             # Add applicable method with api_version preceding it.

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -77,6 +77,9 @@ class QGConnector(api_actions.QGActions):
             if api_version in ('asset management', 'assets', 'tag', 'tagging', 'tags'):
                 # Convert to Asset Management API.
                 api_version = 'am'
+            elif api_version in ('am2'):
+                # Convert to Asset Management API v2
+                api_version = 'am2'
             elif api_version in ('webapp', 'web application scanning', 'webapp scanning'):
                 # Convert to WAS API.
                 api_version = 'was'
@@ -123,6 +126,9 @@ class QGConnector(api_actions.QGActions):
             # QualysGuard REST v3 API url (Portal API).
             url = "https://%s/qps/rest/3.0/" % (self.server,)
         elif api_version == 'am':
+            # QualysGuard REST v1 API url (Portal API).
+            url = "https://%s/qps/rest/1.0/" % (self.server,)
+        elif api_version == 'am2':
             # QualysGuard REST v1 API url (Portal API).
             url = "https://%s/qps/rest/2.0/" % (self.server,)
         else:
@@ -219,7 +225,7 @@ class QGConnector(api_actions.QGActions):
                 # Convert to dictionary.
                 data = urlparse.parse_qs(data)
                 logger.debug('Converted:\n%s' % str(data))
-        elif api_version in ('am', 'was'):
+        elif api_version in ('am', 'was','am2'):
             if type(data) == etree._Element:
                 logger.debug('Converting lxml.builder.E to string')
                 data = etree.tostring(data)
@@ -258,7 +264,7 @@ class QGConnector(api_actions.QGActions):
         headers = {"X-Requested-With": "Parag Baxi QualysAPI (python) v%s" % (qualysapi.version.__version__,)}
         logger.debug('headers =\n%s' % (str(headers)))
         # Portal API takes in XML text, requiring custom header.
-        if api_version in ('am', 'was'):
+        if api_version in ('am', 'was','am2'):
             headers['Content-type'] = 'text/xml'
         #
         # Set up http request method, if not specified.

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -124,7 +124,7 @@ class QGConnector(api_actions.QGActions):
             url = "https://%s/qps/rest/3.0/" % (self.server,)
         elif api_version == 'am':
             # QualysGuard REST v1 API url (Portal API).
-            url = "https://%s/qps/rest/1.0/" % (self.server,)
+            url = "https://%s/qps/rest/2.0/" % (self.server,)
         else:
             raise Exception("Unknown QualysGuard API Version Number (%s)" % (api_version,))
         logger.debug("Base url =\n%s" % (url))


### PR DESCRIPTION
Hi, this better option - add API version am2. The difference between AM1 and AM2 is that count calls are POST in AM2. However, not working correctly as when I tryL
 qgc.request('get/am/hostasset/',api_version='am2')
I get:
<responseCode>OPERATION_NOT_SUPPORTED</responseCode>
Must be that the code still tries POST on this call

Any idea where else a change is needed?
