### PR TITLE
Calling logging.basicConfig breaks logging configuration from an outer scope

### DIFF
--- a/qualysapi/config.py
+++ b/qualysapi/config.py
@@ -6,8 +6,6 @@ import stat
 import getpass
 import logging
 
-logging.basicConfig()
-
 # Setup module level logging.
 logger = logging.getLogger(__name__)
 

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -19,7 +19,6 @@ import qualysapi.api_actions
 import qualysapi.api_actions as api_actions
 
 # Setup module level logging.
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 try:


### PR DESCRIPTION
When calling logging.basicConfig inside the qualysapi module causes any outer configuration using logging.basicConfig in a script utilizing the API breaks. 

Example:
```
import sys
import logging
import qualysapi
logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, datefmt='%Y-%m-%d %H:%M:%S', format='%(asctime)s %(levelname)-8s %(message)s')
logging.debug("This output doesn't get printed to the console.")
```

Commenting out `import qualysapi` in this example causes the logging to work correctly. Traced it back to these two calls to logging.BasicConfig that are completely empty and unnecessary. 