### PR TITLE
Improve urlparse import to support Python 2

### DIFF
--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -9,7 +9,12 @@ and requesting data from it.
 """
 import logging
 import time
-import urllib.parse
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from collections import defaultdict
 
 import requests


### PR DESCRIPTION
The urlparse module is currently imported from urllib.parse, in connector.py, which only exists under Python 3. Updated the import statement to import from the Python 2 variant, urlparse, should the import from urllib.parse fail.

This pull request is to address issue #36 