### PR TITLE
qualys section name as argument

### DIFF
--- a/examples/qualysapi-section-example.py
+++ b/examples/qualysapi-section-example.py
@@ -1,0 +1,113 @@
+__author__ = 'Parag Baxi <parag.baxi@gmail.com>'
+__license__ = 'Apache License 2.0'
+
+import qualysapi
+from lxml import objectify
+from lxml.builder import E
+
+# Setup connection to QualysGuard API.
+qgc = qualysapi.connect('config.txt', 'qualys_vuln')
+#
+# API v1 call: Scan the New York & Las Vegas asset groups
+# The call is our request's first parameter.
+call = 'scan.php'
+# The parameters to append to the url is our request's second parameter.
+parameters = {'scan_title': 'Go big or go home', 'asset_groups': 'New York&Las Vegas', 'option': 'Initial+Options'}
+# Note qualysapi will automatically convert spaces into plus signs for API v1 & v2.
+# Let's call the API and store the result in xml_output.
+xml_output = qgc.request(call, parameters, concurrent_scans_retries=2, concurrent_scans_retry_delay=600)
+# concurrent_retries: Retry the call this many times if your subscription hits the concurrent scans limit.
+# concurrent_retries: Delay in seconds between retrying when subscription hits the concurrent scans limit.
+# Example XML response when this happens below:
+#     <?xml version="1.0" encoding="UTF-8"?>
+#     <ServiceResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://localhost:50205/qps/rest/app//xsd/3.0/was/wasscan.xsd">
+#       <responseCode>INVALID_REQUEST</responseCode>
+#       <responseErrorDetails>
+#         <errorMessage>You have reached the maximum number of concurrent running scans (10) for your account</errorMessage>
+#         <errorResolution>Please wait until your previous scans have completed</errorResolution>
+#       </responseErrorDetails>
+#
+print(xml_output)
+#
+# API v1 call: Print out all IPs associated with asset group "Looneyville Texas".
+# Note that the question mark at the end is optional.
+call = 'asset_group_list.php?'
+# We can still use strings for the data (not recommended).
+parameters = 'title=Looneyville Texas'
+# Let's call the API and store the result in xml_output.
+xml_output = qgc.request(call, parameters)
+# Let's objectify the xml_output string.
+root = objectify.fromstring(xml_output)
+# Print out the IPs.
+print(root.ASSET_GROUP.SCANIPS.IP.text)
+# Prints out:
+# 10.0.0.102
+#
+# API v2 call: Print out DNS name for a range of IPs.
+call = '/api/2.0/fo/asset/host/'
+parameters = {'action': 'list', 'ips': '10.0.0.10-10.0.0.11'}
+xml_output = qgc.request(call, parameters)
+root = objectify.fromstring(xml_output)
+# Iterate hosts and print out DNS name.
+for host in root.RESPONSE.HOST_LIST.HOST:
+    print(host.IP.text, host.DNS.text)
+# Prints out:
+# 10.0.0.10 mydns1.qualys.com
+# 10.0.0.11 mydns2.qualys.com
+#
+# API v3 WAS call: Print out number of webapps.
+call = '/count/was/webapp'
+# Note that this call does not have a payload so we don't send any data parameters.
+xml_output = qgc.request(call)
+root = objectify.fromstring(xml_output)
+# Print out count of webapps.
+print(root.count.text)
+# Prints out:
+# 89
+#
+# API v3 WAS call: Print out number of webapps containing title 'Supafly'.
+call = '/count/was/webapp'
+# We can send a string XML for the data.
+parameters = '<ServiceRequest><filters><Criteria operator="CONTAINS" field="name">Supafly</Criteria></filters></ServiceRequest>'
+xml_output = qgc.request(call, parameters)
+root = objectify.fromstring(xml_output)
+# Print out count of webapps.
+print(root.count.text)
+# Prints out:
+# 3
+#
+# API v3 WAS call: Print out number of webapps containing title 'Lightsabertooth Tiger'.
+call = '/count/was/webapp'
+# We can also send an lxml.builder E object.
+parameters = (
+    E.ServiceRequest(
+        E.filters(
+            E.Criteria('Lightsabertooth Tiger', field='name',operator='CONTAINS'))))
+xml_output = qgc.request(call, parameters)
+root = objectify.fromstring(xml_output)
+# Print out count of webapps.
+print(root.count.text)
+# Prints out:
+# 0
+# Too bad, because that is an awesome webapp name!
+#
+# API v3 Asset Management call: Count tags.
+call = '/count/am/tag'
+xml_output = qgc.request(call)
+root = objectify.fromstring(xml_output)
+# We can use XPATH to find the count.
+print(root.xpath('count')[0].text)
+# Prints out:
+# 840
+#
+# API v3 Asset Management call: Find asset by name.
+call = '/search/am/tag'
+parameters = '''<ServiceRequest>
+        <preferences>
+            <limitResults>10</limitResults>
+        </preferences>
+        <filters>
+            <Criteria field="name" operator="CONTAINS">PB</Criteria>
+        </filters>
+    </ServiceRequest>'''
+xml_output = qgc.request(call, parameters)

--- a/qualysapi/config.py
+++ b/qualysapi/config.py
@@ -30,10 +30,10 @@ class QualysConnectConfig:
     from an ini file.
     """
 
-    def __init__(self, filename=qcs.default_filename, remember_me=False, remember_me_always=False):
+    def __init__(self, filename=qcs.default_filename, section='info', remember_me=False, remember_me_always=False):
 
         self._cfgfile = None
-
+        self._section = section
         # Prioritize local directory filename.
         # Check for file existence.
         if os.path.exists(filename):
@@ -56,30 +56,30 @@ class QualysConnectConfig:
 
             self._cfgparse.read(self._cfgfile)
 
-        # if 'info' doesn't exist, create the section.
-        if not self._cfgparse.has_section('info'):
-            self._cfgparse.add_section('info')
+        # if 'info'/ specified section doesn't exist, create the section.
+        if not self._cfgparse.has_section(self._section):
+            self._cfgparse.add_section(self._section)
 
         # Use default hostname (if one isn't provided).
-        if not self._cfgparse.has_option('info', 'hostname'):
+        if not self._cfgparse.has_option(self._section, 'hostname'):
             if self._cfgparse.has_option('DEFAULT', 'hostname'):
                 hostname = self._cfgparse.get('DEFAULT', 'hostname')
-                self._cfgparse.set('info', 'hostname', hostname)
+                self._cfgparse.set(self._section, 'hostname', hostname)
             else:
                 raise Exception("No 'hostname' set. QualysConnect does not know who to connect to.")
 
         # Use default max_retries (if one isn't provided).
-        if not self._cfgparse.has_option('info', 'max_retries'):
+        if not self._cfgparse.has_option(self._section, 'max_retries'):
             self.max_retries = qcs.defaults['max_retries']
         else:
-            self.max_retries = self._cfgparse.get('info', 'max_retries')
+            self.max_retries = self._cfgparse.get(self._section, 'max_retries')
             try:
                 self.max_retries = int(self.max_retries)
             except Exception:
                 logger.error('Value max_retries must be an integer.')
                 print('Value max_retries must be an integer.')
                 exit(1)
-            self._cfgparse.set('info', 'max_retries', str(self.max_retries))
+            self._cfgparse.set(self._section, 'max_retries', str(self.max_retries))
         self.max_retries = int(self.max_retries)
 
         # Proxy support
@@ -153,16 +153,16 @@ class QualysConnectConfig:
             self.proxies = None
 
         # ask username (if one doesn't exist)
-        if not self._cfgparse.has_option('info', 'username'):
+        if not self._cfgparse.has_option(self._section, 'username'):
             username = input('QualysGuard Username: ')
-            self._cfgparse.set('info', 'username', username)
+            self._cfgparse.set(self._section, 'username', username)
 
         # ask password (if one doesn't exist)
-        if not self._cfgparse.has_option('info', 'password'):
+        if not self._cfgparse.has_option(self._section, 'password'):
             password = getpass.getpass('QualysGuard Password: ')
-            self._cfgparse.set('info', 'password', password)
+            self._cfgparse.set(self._section, 'password', password)
 
-        logger.debug(self._cfgparse.items('info'))
+        logger.debug(self._cfgparse.items(self._section))
 
         if remember_me or remember_me_always:
             # Let's create that config file for next time...
@@ -194,8 +194,8 @@ class QualysConnectConfig:
 
     def get_auth(self):
         ''' Returns username from the configfile. '''
-        return (self._cfgparse.get('info', 'username'), self._cfgparse.get('info', 'password'))
+        return (self._cfgparse.get(self._section, 'username'), self._cfgparse.get(self._section, 'password'))
 
     def get_hostname(self):
         ''' Returns hostname. '''
-        return self._cfgparse.get('info', 'hostname')
+        return self._cfgparse.get(self._section, 'hostname')

--- a/qualysapi/util.py
+++ b/qualysapi/util.py
@@ -14,12 +14,12 @@ __license__ = 'Apache License 2.0'
 logger = logging.getLogger(__name__)
 
 
-def connect(config_file=qcs.default_filename, remember_me=False, remember_me_always=False):
+def connect(config_file=qcs.default_filename, section='info', remember_me=False, remember_me_always=False):
     """ Return a QGAPIConnect object for v1 API pulling settings from config
     file.
     """
     # Retrieve login credentials.
-    conf = qcconf.QualysConnectConfig(filename=config_file, remember_me=remember_me,
+    conf = qcconf.QualysConnectConfig(filename=config_file, section=section, remember_me=remember_me,
                                       remember_me_always=remember_me_always)
     connect = qcconn.QGConnector(conf.get_auth(),
                                  conf.get_hostname(),


### PR DESCRIPTION
This change is for being allowed to specify the section name that contains the qualys credentials, so that you can work with different qualys solutions using the same config file. If no section name is specified, default section name continues being "info".

Thanks for the library!