### PR TITLE
lxml/string return compatibility work

### DIFF
--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -40,9 +40,9 @@ class QGActions(object):
     def listAssetGroups(self, groupName=''):
         call = 'asset_group_list.php'
         if groupName == '':
-            agData = objectify.fromstring(self.request(call))
+            agData = objectify.fromstring(self.request(call).encode('utf-8'))
         else:
-            agData = objectify.fromstring(self.request(call, 'title=' + groupName)).RESPONSE
+            agData = objectify.fromstring(self.request(call, 'title=' + groupName).encode('utf-8')).RESPONSE
 
         groupsArray = []
         scanipsArray = []

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -227,19 +227,24 @@ class QGActions(object):
     def launchScan(self, title, option_title, iscanner_name, asset_groups="", ip=""):
         # TODO: Add ability to scan by tag.
         call = '/api/2.0/fo/scan/'
-        parameters = {'action': 'launch', 'scan_title': title, 'option_title': option_title, 'iscanner_name': iscanner_name, 'ip': ip, 'asset_groups': asset_groups}
+        parameters = {'action': 'launch',
+                      'scan_title': title,
+                      'option_title': option_title,
+                      'iscanner_name': iscanner_name,
+                      'ip': ip,
+                      'asset_groups': asset_groups}
         if ip == "":
             parameters.pop("ip")
 
         if asset_groups == "":
             parameters.pop("asset_groups")
 
-        scan_ref = objectify.fromstring(self.request(call, parameters)).RESPONSE.ITEM_LIST.ITEM[1].VALUE
+        scan_ref = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE.ITEM_LIST.ITEM[1].VALUE
 
         call = '/api/2.0/fo/scan/'
         parameters = {'action': 'list', 'scan_ref': scan_ref, 'show_status': 1, 'show_ags': 1, 'show_op': 1}
 
-        scan = objectify.fromstring(self.request(call, parameters)).RESPONSE.SCAN_LIST.SCAN
+        scan = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN
         try:
             agList = []
             for ag in scan.ASSET_GROUP_TITLE_LIST.ASSET_GROUP_TITLE:
@@ -247,4 +252,15 @@ class QGActions(object):
         except AttributeError:
             agList = []
 
-        return Scan(agList, scan.DURATION, scan.LAUNCH_DATETIME, scan.OPTION_PROFILE.TITLE, scan.PROCESSED, scan.REF, scan.STATUS, scan.TARGET, scan.TITLE, scan.TYPE, scan.USER_LOGIN)
+        return Scan(agList,
+                    scan.find('DURATION'),
+                    scan.find('LAUNCH_DATETIME'),
+                    scan.find('OPTION_PROFILE.TITLE'),
+                    scan.find('PROCESSED'),
+                    scan.find('REF'),
+                    scan.find('STATUS'),
+                    scan.find('TARGET'),
+                    scan.find('TITLE'),
+                    scan.find('TYPE'),
+                    scan.find('USER_LOGIN')
+                    )

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -67,17 +67,33 @@ class QGActions(object):
             except AttributeError:
                 scandnsArray = []  # No DNS names assigned to group.
 
-            groupsArray.append(AssetGroup(group.BUSINESS_IMPACT, group.ID, group.LAST_UPDATE, scanipsArray, scandnsArray, scannersArray, group.TITLE))
+            groupsArray.append(AssetGroup(group.find('BUSINESS_IMPACT'),
+                                          group.find('ID'),
+                                          group.find('LAST_UPDATE'),
+                                          scanipsArray,
+                                          scandnsArray,
+                                          scannersArray,
+                                          group.find('TITLE')
+                                          )
+                               )
 
         return groupsArray
 
     def listReportTemplates(self):
         call = 'report_template_list.php'
-        rtData = objectify.fromstring(self.request(call))
+        rtData = objectify.fromstring(self.request(call).encode('utf-8'))
         templatesArray = []
 
         for template in rtData.REPORT_TEMPLATE:
-            templatesArray.append(ReportTemplate(template.GLOBAL, template.ID, template.LAST_UPDATE, template.TEMPLATE_TYPE, template.TITLE, template.TYPE, template.USER))
+            templatesArray.append(ReportTemplate(template.find('GLOBAL'),
+                                                 template.find('ID'),
+                                                 template.find('LAST_UPDATE'),
+                                                 template.find('TEMPLATE_TYPE'),
+                                                 template.find('TITLE'),
+                                                 template.find('TYPE'),
+                                                 template.find('USER')
+                                                 )
+                                  )
 
         return templatesArray
 
@@ -87,18 +103,38 @@ class QGActions(object):
         if id == 0:
             parameters = {'action': 'list'}
 
-            repData = objectify.fromstring(self.request(call, parameters)).RESPONSE
+            repData = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE
             reportsArray = []
 
             for report in repData.REPORT_LIST.REPORT:
-                reportsArray.append(Report(report.EXPIRATION_DATETIME, report.ID, report.LAUNCH_DATETIME, report.OUTPUT_FORMAT, report.SIZE, report.STATUS, report.TYPE, report.USER_LOGIN))
+                reportsArray.append(Report(report.find('EXPIRATION_DATETIME'),
+                                           report.find('ID'),
+                                           report.find('LAUNCH_DATETIME'),
+                                           report.find('OUTPUT_FORMAT'),
+                                           report.find('SIZE'),
+                                           report.find('STATUS'),
+                                           report.find('TYPE'),
+                                           report.find('USER_LOGIN'),
+                                           report.find('TITLE')
+                                           )
+                                    )
 
             return reportsArray
 
         else:
             parameters = {'action': 'list', 'id': id}
-            repData = objectify.fromstring(self.request(call, parameters)).RESPONSE.REPORT_LIST.REPORT
-            return Report(repData.EXPIRATION_DATETIME, repData.ID, repData.LAUNCH_DATETIME, repData.OUTPUT_FORMAT, repData.SIZE, repData.STATUS, repData.TYPE, repData.USER_LOGIN)
+            repData = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE.REPORT_LIST.REPORT
+
+            return Report(repData.find('EXPIRATION_DATETIME'),
+                          repData.find('ID'),
+                          repData.find('LAUNCH_DATETIME'),
+                          repData.find('OUTPUT_FORMAT'),
+                          repData.find('SIZE'),
+                          repData.find('STATUS'),
+                          repData.find('TYPE'),
+                          repData.find('USER_LOGIN'),
+                          repData.find('TITLE')
+                          )
 
     def notScannedSince(self, days):
         call = '/api/2.0/fo/asset/host/'

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -198,7 +198,7 @@ class QGActions(object):
         if user_login != "":
             parameters['user_login'] = user_login
 
-        scanlist = objectify.fromstring(self.request(call, parameters))
+        scanlist = objectify.fromstring(self.request(call, parameters).encode('utf-8'))
         scanArray = []
         for scan in scanlist.RESPONSE.SCAN_LIST.SCAN:
             try:
@@ -208,7 +208,19 @@ class QGActions(object):
             except AttributeError:
                 agList = []
 
-            scanArray.append(Scan(agList, scan.DURATION, scan.LAUNCH_DATETIME, scan.OPTION_PROFILE.TITLE, scan.PROCESSED, scan.REF, scan.STATUS, scan.TARGET, scan.TITLE, scan.TYPE, scan.USER_LOGIN))
+            scanArray.append(Scan(agList,
+                                  scan.find('DURATION'),
+                                  scan.find('LAUNCH_DATETIME'),
+                                  scan.find('OPTION_PROFILE.TITLE'),
+                                  scan.find('PROCESSED'),
+                                  scan.find('REF'),
+                                  scan.find('STATUS'),
+                                  scan.find('TARGET'),
+                                  scan.find('TITLE'),
+                                  scan.find('TYPE'),
+                                  scan.find('USER_LOGIN')
+                                  )
+                             )
 
         return scanArray
 

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -139,14 +139,23 @@ class QGActions(object):
     def notScannedSince(self, days):
         call = '/api/2.0/fo/asset/host/'
         parameters = {'action': 'list', 'details': 'All'}
-        hostData = objectify.fromstring(self.request(call, parameters))
+        hostData = objectify.fromstring(self.request(call, parameters).encode('utf-8'))
         hostArray = []
         today = datetime.date.today()
         for host in hostData.RESPONSE.HOST_LIST.HOST:
-            last_scan = str(host.LAST_VULN_SCAN_DATETIME).split('T')[0]
-            last_scan = datetime.date(int(last_scan.split('-')[0]), int(last_scan.split('-')[1]), int(last_scan.split('-')[2]))
-            if (today - last_scan).days >= days:
-                hostArray.append(Host(host.DNS, host.ID, host.IP, host.LAST_VULN_SCAN_DATETIME, host.NETBIOS, host.OS, host.TRACKING_METHOD))
+            if host.find('LAST_VULN_SCAN_DATETIME'):
+                last_scan = str(host.LAST_VULN_SCAN_DATETIME).split('T')[0]
+                last_scan = datetime.date(int(last_scan.split('-')[0]), int(last_scan.split('-')[1]), int(last_scan.split('-')[2]))
+                if (today - last_scan).days >= days:
+                    hostArray.append(Host(host.find('DNS'),
+                                          host.find('ID'),
+                                          host.find('IP'),
+                                          host.find('LAST_VULN_SCAN_DATETIME'),
+                                          host.find('NETBIOS'),
+                                          host.find('OS'),
+                                          host.find('TRACKING_METHOD')
+                                          )
+                                     )
 
         return hostArray
 

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -5,13 +5,20 @@ from qualysapi.api_objects import *
 
 
 class QGActions(object):
-    def getHost(host):
+    def getHost(self, host):
         call = '/api/2.0/fo/asset/host/'
         parameters = {'action': 'list', 'ips': host, 'details': 'All'}
-        hostData = objectify.fromstring(self.request(call, parameters)).RESPONSE
+        hostData = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE
         try:
             hostData = hostData.HOST_LIST.HOST
-            return Host(hostData.DNS, hostData.ID, hostData.IP, hostData.LAST_VULN_SCAN_DATETIME, hostData.NETBIOS, hostData.OS, hostData.TRACKING_METHOD)
+            return Host(hostData.find('DNS'),
+                        hostData.find('ID'),
+                        hostData.find('IP'),
+                        hostData.find('LAST_VULN_SCAN_DATETIME'),
+                        hostData.find('NETBIOS'),
+                        hostData.find('OS'),
+                        hostData.find('TRACKING_METHOD')
+                        )
         except AttributeError:
             return Host("", "", host, "never", "", "", "")
 

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -42,7 +42,7 @@ class QGActions(object):
         if groupName == '':
             agData = objectify.fromstring(self.request(call).encode('utf-8'))
         else:
-            agData = objectify.fromstring(self.request(call, 'title=' + groupName).encode('utf-8')).RESPONSE
+            agData = objectify.fromstring(self.request(call, 'title=' + groupName).encode('utf-8'))
 
         groupsArray = []
         scanipsArray = []

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -25,10 +25,18 @@ class QGActions(object):
     def getHostRange(self, start, end):
         call = '/api/2.0/fo/asset/host/'
         parameters = {'action': 'list', 'ips': start + '-' + end}
-        hostData = objectify.fromstring(self.request(call, parameters))
+        hostData = objectify.fromstring(self.request(call, parameters).encode('utf-8'))
         hostArray = []
         for host in hostData.RESPONSE.HOST_LIST.HOST:
-            hostArray.append(Host(host.DNS, host.ID, host.IP, host.LAST_VULN_SCAN_DATETIME, host.NETBIOS, host.OS, host.TRACKING_METHOD))
+            hostArray.append(Host(host.find('DNS'),
+                                  host.find('ID'),
+                                  host.find('IP'),
+                                  host.find('LAST_VULN_SCAN_DATETIME'),
+                                  host.find('NETBIOS'),
+                                  host.find('OS'),
+                                  host.find('TRACKING_METHOD')
+                                  )
+                             )
 
         return hostArray
 

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -9,18 +9,15 @@ class QGActions(object):
         call = '/api/2.0/fo/asset/host/'
         parameters = {'action': 'list', 'ips': host, 'details': 'All'}
         hostData = objectify.fromstring(self.request(call, parameters).encode('utf-8')).RESPONSE
-        try:
-            hostData = hostData.HOST_LIST.HOST
-            return Host(hostData.find('DNS'),
-                        hostData.find('ID'),
-                        hostData.find('IP'),
-                        hostData.find('LAST_VULN_SCAN_DATETIME'),
-                        hostData.find('NETBIOS'),
-                        hostData.find('OS'),
-                        hostData.find('TRACKING_METHOD')
-                        )
-        except AttributeError:
-            return Host("", "", host, "never", "", "", "")
+        hostData = hostData.HOST_LIST.HOST
+        return Host(hostData.find('DNS'),
+                    hostData.find('ID'),
+                    hostData.find('IP'),
+                    hostData.find('LAST_VULN_SCAN_DATETIME'),
+                    hostData.find('NETBIOS'),
+                    hostData.find('OS'),
+                    hostData.find('TRACKING_METHOD')
+                    )
 
     def getHostRange(self, start, end):
         call = '/api/2.0/fo/asset/host/'

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -145,7 +145,8 @@ class QGActions(object):
         for host in hostData.RESPONSE.HOST_LIST.HOST:
             if host.find('LAST_VULN_SCAN_DATETIME'):
                 last_scan = str(host.LAST_VULN_SCAN_DATETIME).split('T')[0]
-                last_scan = datetime.date(int(last_scan.split('-')[0]), int(last_scan.split('-')[1]), int(last_scan.split('-')[2]))
+                last_scan = datetime.date(int(last_scan.split('-')[0]), int(last_scan.split('-')[1]),
+                                          int(last_scan.split('-')[2]))
                 if (today - last_scan).days >= days:
                     hostArray.append(Host(host.find('DNS'),
                                           host.find('ID'),

--- a/qualysapi/api_methods.py
+++ b/qualysapi/api_methods.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 __author__ = 'pbaxi'
 
 from collections import defaultdict

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -112,7 +112,7 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters)).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
 
     def pause(self, conn):
         if self.status != "Running":
@@ -123,7 +123,7 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters)).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
 
     def resume(self, conn):
         if self.status != "Paused":
@@ -134,4 +134,4 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters)).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -12,7 +12,8 @@ class Host(object):
             last_scan = str(last_scan).replace('T', ' ').replace('Z', '').split(' ')
             date = last_scan[0].split('-')
             time = last_scan[1].split(':')
-            self.last_scan = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(time[0]), int(time[1]), int(time[2]))
+            self.last_scan = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(time[0]), int(time[1]),
+                                               int(time[2]))
         except IndexError:
             self.last_scan = 'never'
         self.netbios = str(netbios)
@@ -47,6 +48,7 @@ class AssetGroup(object):
     def __repr__(self):
         return f"qualys_id: {self.id}, title: {self.title}"
 
+
 class ReportTemplate(object):
     def __init__(self, isGlobal, id, last_update, template_type, title, type, user):
         self.isGlobal = int(isGlobal)
@@ -60,8 +62,10 @@ class ReportTemplate(object):
     def __repr__(self):
         return f"qualys_id: {self.id}, title: {self.title}"
 
+
 class Report(object):
-    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login, title=''):
+    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login,
+                 title=''):
         self.expiration_datetime = str(expiration_datetime).replace('T', ' ').replace('Z', '').split(' ')
         self.id = int(id)
         self.launch_datetime = str(launch_datetime).replace('T', ' ').replace('Z', '').split(' ')
@@ -83,13 +87,19 @@ class Report(object):
 
 
 class Scan(object):
-    def __init__(self, assetgroups, duration, launch_datetime, option_profile, processed, ref, status, target, title, type, user_login):
+    def __init__(self, assetgroups, duration, launch_datetime, option_profile, processed, ref, status, target, title,
+                 type, user_login):
         self.assetgroups = assetgroups
         self.duration = str(duration)
         launch_datetime = str(launch_datetime).replace('T', ' ').replace('Z', '').split(' ')
         date = launch_datetime[0].split('-')
         time = launch_datetime[1].split(':')
-        self.launch_datetime = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(time[0]), int(time[1]), int(time[2]))
+        self.launch_datetime = datetime.datetime(int(date[0]),
+                                                 int(date[1]),
+                                                 int(date[2]),
+                                                 int(time[0]),
+                                                 int(time[1]),
+                                                 int(time[2]))
         self.option_profile = str(option_profile)
         self.processed = int(processed)
         self.ref = str(ref)
@@ -112,7 +122,8 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(
+                conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
 
     def pause(self, conn):
         if self.status != "Running":
@@ -123,7 +134,8 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(
+                conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
 
     def resume(self, conn):
         if self.status != "Paused":
@@ -134,4 +146,5 @@ class Scan(object):
             conn.request(call, parameters)
 
             parameters = {'action': 'list', 'scan_ref': self.ref, 'show_status': 1}
-            self.status = objectify.fromstring(conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE
+            self.status = objectify.fromstring(
+                conn.request(call, parameters).encode('utf-8')).RESPONSE.SCAN_LIST.SCAN.STATUS.STATE

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -44,6 +44,8 @@ class AssetGroup(object):
         parameters = {'action': 'edit', 'id': self.id, 'set_ips': ips}
         conn.request(call, parameters)
 
+    def __repr__(self):
+        return f"qualys_id: {self.id}, title: {self.title}"
 
 class ReportTemplate(object):
     def __init__(self, isGlobal, id, last_update, template_type, title, type, user):

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -19,7 +19,7 @@ class Host(object):
         self.os = str(os)
         self.tracking_method = str(tracking_method)
 
-    def __str__(self):
+    def __repr__(self):
         return f"ip: {self.ip}, qualys_id: {self.id}, dns: {self.dns}"
 
 

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -57,9 +57,11 @@ class ReportTemplate(object):
         self.type = type
         self.user = user.LOGIN
 
+    def __repr__(self):
+        return f"qualys_id: {self.id}, title: {self.title}"
 
 class Report(object):
-    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login):
+    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login, title):
         self.expiration_datetime = str(expiration_datetime).replace('T', ' ').replace('Z', '').split(' ')
         self.id = int(id)
         self.launch_datetime = str(launch_datetime).replace('T', ' ').replace('Z', '').split(' ')
@@ -68,6 +70,10 @@ class Report(object):
         self.status = status.STATE
         self.type = type
         self.user_login = user_login
+        self.title = title
+
+    def __repr__(self):
+        return f"qualys_id: {self.id}, title: {self.title}"
 
     def download(self, conn):
         call = '/api/2.0/fo/report'

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -99,6 +99,9 @@ class Scan(object):
         self.type = str(type)
         self.user_login = str(user_login)
 
+    def __repr__(self):
+        return f"qualys_ref: {self.ref}, title: {self.title}, option_profile: {self.option_profile}"
+
     def cancel(self, conn):
         cancelled_statuses = ['Cancelled', 'Finished', 'Error']
         if any(self.status in s for s in cancelled_statuses):

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -8,13 +8,19 @@ class Host(object):
         self.dns = str(dns)
         self.id = int(id)
         self.ip = str(ip)
-        last_scan = str(last_scan).replace('T', ' ').replace('Z', '').split(' ')
-        date = last_scan[0].split('-')
-        time = last_scan[1].split(':')
-        self.last_scan = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(time[0]), int(time[1]), int(time[2]))
+        try:
+            last_scan = str(last_scan).replace('T', ' ').replace('Z', '').split(' ')
+            date = last_scan[0].split('-')
+            time = last_scan[1].split(':')
+            self.last_scan = datetime.datetime(int(date[0]), int(date[1]), int(date[2]), int(time[0]), int(time[1]), int(time[2]))
+        except IndexError:
+            self.last_scan = 'never'
         self.netbios = str(netbios)
         self.os = str(os)
         self.tracking_method = str(tracking_method)
+
+    def __str__(self):
+        return f"ip: {self.ip}, qualys_id: {self.id}, dns: {self.dns}"
 
 
 class AssetGroup(object):

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -61,7 +61,7 @@ class ReportTemplate(object):
         return f"qualys_id: {self.id}, title: {self.title}"
 
 class Report(object):
-    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login, title):
+    def __init__(self, expiration_datetime, id, launch_datetime, output_format, size, status, type, user_login, title=''):
         self.expiration_datetime = str(expiration_datetime).replace('T', ' ').replace('Z', '').split(' ')
         self.id = int(id)
         self.launch_datetime = str(launch_datetime).replace('T', ' ').replace('Z', '').split(' ')

--- a/qualysapi/config.py
+++ b/qualysapi/config.py
@@ -11,6 +11,7 @@ from six.moves import input
 from six.moves.configparser import *
 
 import qualysapi.settings as qcs
+
 # Setup module level logging.
 logger = logging.getLogger(__name__)
 

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -12,6 +12,7 @@ import time
 
 try:
     from urllib.parse import urlparse
+    from urllib.parse import parse_qs
 except ImportError:
     from urlparse import urlparse
 
@@ -220,7 +221,7 @@ class QGConnector(api_actions.QGActions):
                 data = data.lstrip('?')
                 data = data.rstrip('&')
                 # Convert to dictionary.
-                data = urlparse.parse_qs(data)
+                data = parse_qs(data)
                 logger.debug('Converted:\n%s' % str(data))
         elif api_version in ('am', 'was', 'am2'):
             if type(data) == etree._Element:
@@ -317,7 +318,7 @@ class QGConnector(api_actions.QGActions):
                 logger.debug(e)
                 pass
             # Response received.
-            response = str(request.content)
+            response = request.text
             logger.debug('response text =\n%s' % (response))
             # Keep track of how many retries.
             retries += 1

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+
 __author__ = 'Parag Baxi <parag.baxi@gmail.com>'
 __copyright__ = 'Copyright 2013, Parag Baxi'
 __license__ = 'Apache License 2.0'
@@ -305,10 +306,14 @@ class QGConnector(api_actions.QGActions):
                 logger.debug('rate limit for api_call, %s = %s' % (api_call, self.rate_limit_remaining[api_call]))
                 if (self.rate_limit_remaining[api_call] > rate_warn_threshold):
                     logger.debug('rate limit for api_call, %s = %s' % (api_call, self.rate_limit_remaining[api_call]))
-                elif (self.rate_limit_remaining[api_call] <= rate_warn_threshold) and (self.rate_limit_remaining[api_call] > 0):
-                    logger.warning('Rate limit is about to being reached (remaining api calls = %s)' % self.rate_limit_remaining[api_call])
+                elif (self.rate_limit_remaining[api_call] <= rate_warn_threshold) and (
+                        self.rate_limit_remaining[api_call] > 0):
+                    logger.warning(
+                        'Rate limit is about to being reached (remaining api calls = %s)' % self.rate_limit_remaining[
+                            api_call])
                 elif self.rate_limit_remaining[api_call] <= 0:
-                    logger.critical('ATTENTION! RATE LIMIT HAS BEEN REACHED (remaining api calls = %s)!' % self.rate_limit_remaining[api_call])
+                    logger.critical('ATTENTION! RATE LIMIT HAS BEEN REACHED (remaining api calls = %s)!' %
+                                    self.rate_limit_remaining[api_call])
             except KeyError as e:
                 # Likely a bad api_call.
                 logger.debug(e)


### PR DESCRIPTION
I have gone through and attempted to identify where additional .encode() statements were required to allow for the API objects to function correctly. 

In my testing I also found it beneficial to add a __repr__() to some objects. 

An optional "title" attribute has been added to the Report object type to make the repr more meaningful.

I have updated the method to get XML data to use "find()" as this will return blank if the entry is not present, I found this as not all my sample hosts had a NETBIOS name. It seems to offer a safer way to access data that may legitimately not exist  but otherwise not be a real problem.

There were some minor changes in formatting in the final commit through automated linting.
