### PR TITLE
Fix for Python2.7, add minimal smoke tests to CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+Pipfile
+Pipfile\.lock
 
 # Installer logs
 pip-log.txt
@@ -42,12 +44,7 @@ nosetests.xml
 config.qcrc
 config.ini
 
-# PyCharm
+# IDE stuff
 .idea
 .qcrc.swp
-
 \.vscode/
-
-Pipfile
-
-Pipfile\.lock

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ config.ini
 # PyCharm
 .idea
 .qcrc.swp
+
+\.vscode/
+
+Pipfile
+
+Pipfile\.lock

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+coverage\.xml
+\.pytest_cache/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install: "make"
 before_script:
     - make lint
 script:
-    - true  
-    # - make test
+    - make test
 after_success:
     # send report to https://coveralls.io/github/paragbaxi/qualysapi
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 cache: pip
 python:
     - 2.7
+    - 3.5
     - 3.6
 # Enable newer 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 matrix:
   allow_failures:
     - python: 3.8-dev
+    - python: 3.5
   include:
     - python: 3.7
       dist: xenial

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ else
 endif
 
 lint:
-	# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-	flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 ifeq ($(TRAVIS_PYTHON_VERSION), 3.6)
+		# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+		flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 		# stop the build if there are Python syntax errors or undefined names
 		flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 else
-		echo "Only fail lint for Python3.6"
+		echo "Only lint on Python3.6"
 endif
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ init:
 	pip install -r reqs/dev-requirements.txt
 ifeq ($(TRAVIS), true)
 		pip install .
+else
+	pip install -r reqs/requirements.txt
 endif
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 init:
+	pip install -r reqs/dev-requirements.txt
 ifeq ($(TRAVIS), true)
 		pip install .
 endif
-	pip install -r reqs/dev-requirements.txt
 
 lint:
 	# exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 init:
+ifeq ($(TRAVIS), true)
+		pip install .
+endif
 	pip install -r reqs/dev-requirements.txt
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ init:
 ifeq ($(TRAVIS), true)
 		pip install .
 else
-	pip install -r reqs/requirements.txt
+		pip install -r reqs/requirements.txt
 endif
 
 lint:

--- a/qualysapi/__init__.py
+++ b/qualysapi/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 # This is the version string assigned to the entire egg post
 # setup.py install
 

--- a/qualysapi/api_actions.py
+++ b/qualysapi/api_actions.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from __future__ import absolute_import
 from lxml import objectify
 import qualysapi.api_objects

--- a/qualysapi/api_methods.py
+++ b/qualysapi/api_methods.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from __future__ import absolute_import
 
 __author__ = 'pbaxi'

--- a/qualysapi/api_objects.py
+++ b/qualysapi/api_objects.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from __future__ import absolute_import
 import datetime
 from lxml import objectify

--- a/qualysapi/config.py
+++ b/qualysapi/config.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 """ Module providing a single class (QualysConnectConfig) that parses a config
 file and provides the information required to build QualysGuard sessions.
 """

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/qualysapi/settings.py
+++ b/qualysapi/settings.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 ''' Module to hold global settings reused throughout qualysapi. '''
 
 from __future__ import absolute_import

--- a/qualysapi/util.py
+++ b/qualysapi/util.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 """ A set of utility functions for QualysConnect module. """
 from __future__ import absolute_import
 import logging

--- a/qualysapi/version.py
+++ b/qualysapi/version.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 __author__ = 'Parag Baxi <parag.baxi@gmail.com>'
 __pkgname__ = 'qualysapi'
 __version__ = '5.0.4'

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 pathlib2;python_version == '2.7'
-flake8
+flake8;python_version < '3.8'
 pytest
 coverage
 pytest-cov

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-pathlib2;python_version == '2.7'
 flake8;python_version < '3.8'
 pytest
 coverage

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,3 +1,4 @@
+future-fstrings
 flake8;python_version < '3.8'
 pytest
 coverage

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 flake8;python_version < '3.8'
 pytest
 coverage

--- a/reqs/dev-requirements.txt
+++ b/reqs/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+pathlib2;python_version == '2.7'
 flake8
 pytest
 coverage

--- a/reqs/requirements.txt
+++ b/reqs/requirements.txt
@@ -1,3 +1,4 @@
 requests
 lxml
 future-fstrings
+pathlib2;python_version == '2.7'

--- a/reqs/requirements.txt
+++ b/reqs/requirements.txt
@@ -1,3 +1,3 @@
 requests
 lxml
-future-fstrings;python_version < '3.6'
+future-fstrings

--- a/reqs/requirements.txt
+++ b/reqs/requirements.txt
@@ -1,2 +1,3 @@
 requests
-pathlib2;python_version == '2.7'
+lxml
+future-fstrings;python_version < '3.6'

--- a/reqs/requirements.txt
+++ b/reqs/requirements.txt
@@ -1,1 +1,2 @@
 requests
+pathlib2;python_version == '2.7'

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 # -*- coding: future_fstrings -*-
+#!/usr/bin/env python
+
 from __future__ import absolute_import
 import os
 import sys
-
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-__author__ = "Parag Baxi <parag.baxi@gmail.com>"
-__copyright__ = "Copyright 2011-2018, Parag Baxi"
-__license__ = "BSD-new"
+__author__ = 'Parag Baxi <parag.baxi@gmail.com>'
+__copyright__ = 'Copyright 2011-2018, Parag Baxi'
+__license__ = 'BSD-new'
 # Make pyflakes happy.
 __pkgname__ = None
 __version__ = None
-exec(compile(open("qualysapi/version.py").read(), "qualysapi/version.py", "exec"))
+exec(compile(open('qualysapi/version.py').read(), 'qualysapi/version.py', 'exec'))
 REQUIREMENTS = ["requests", "lxml", "future-fstrings"]
 
 
@@ -26,29 +27,28 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-setup(
-    name=__pkgname__,
-    version=__version__,
-    author="Parag Baxi",
-    author_email="parag.baxi@gmail.com",
-    description="QualysGuard(R) Qualys API Package",
-    license="BSD-new",
-    keywords="Qualys QualysGuard API helper network security",
-    url="https://github.com/paragbaxi/qualysapi",
-    package_dir={"": "."},
-    packages=["qualysapi"],
-    # package_data={'qualysapi':['LICENSE']},
-    # scripts=['src/scripts/qhostinfo.py', 'src/scripts/qscanhist.py', 'src/scripts/qreports.py'],
-    long_description=read("README.md"),
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: Apache Software License",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+setup(name=__pkgname__,
+      version=__version__,
+      author='Parag Baxi',
+      author_email='parag.baxi@gmail.com',
+      description='QualysGuard(R) Qualys API Package',
+      license='BSD-new',
+      keywords='Qualys QualysGuard API helper network security',
+      url='https://github.com/paragbaxi/qualysapi',
+      package_dir={'': '.'},
+      packages=['qualysapi', ],
+      # package_data={'qualysapi':['LICENSE']},
+      # scripts=['src/scripts/qhostinfo.py', 'src/scripts/qscanhist.py', 'src/scripts/qreports.py'],
+      long_description=read('README.md'),
+      classifiers=[
+          'Development Status :: 5 - Production/Stable',
+          'Topic :: Utilities',
+          'License :: OSI Approved :: Apache Software License',
+          'Intended Audience :: Developers',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
     ],
     install_requires=REQUIREMENTS,
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,12 @@ __license__ = 'BSD-new'
 __pkgname__ = None
 __version__ = None
 exec(compile(open('qualysapi/version.py').read(), 'qualysapi/version.py', 'exec'))
-REQUIREMENTS = ["requests", "lxml", "future-fstrings"]
+REQUIREMENTS = [
+    "requests",
+    "lxml",
+    "future-fstrings",
+    "pathlib2 ; python_version == '2.7'",
+]
 
 
 # A utility function to read the README file into the long_description field.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ __license__ = 'BSD-new'
 __pkgname__ = None
 __version__ = None
 exec(compile(open('qualysapi/version.py').read(), 'qualysapi/version.py', 'exec'))
-REQUIREMENTS = ["requests", "lxml"]
+REQUIREMENTS = ["requests", "lxml", "future-fstrings ; python_version<'3.6'"]
 
 
 # A utility function to read the README file into the long_description field.

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,5 @@ setup(name=__pkgname__,
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
       ],
-      install_requires=[
-          'requests',
-      ],
     install_requires=REQUIREMENTS,
      )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 # -*- coding: future_fstrings -*-
-#!/usr/bin/env python
-
 from __future__ import absolute_import
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,23 @@
+# -*- coding: future_fstrings -*-
 #!/usr/bin/env python
 
 from __future__ import absolute_import
 import os
 import sys
+
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-__author__ = 'Parag Baxi <parag.baxi@gmail.com>'
-__copyright__ = 'Copyright 2011-2018, Parag Baxi'
-__license__ = 'BSD-new'
+__author__ = "Parag Baxi <parag.baxi@gmail.com>"
+__copyright__ = "Copyright 2011-2018, Parag Baxi"
+__license__ = "BSD-new"
 # Make pyflakes happy.
 __pkgname__ = None
 __version__ = None
-exec(compile(open('qualysapi/version.py').read(), 'qualysapi/version.py', 'exec'))
-REQUIREMENTS = ["requests", "lxml", "future-fstrings ; python_version<'3.6'"]
+exec(compile(open("qualysapi/version.py").read(), "qualysapi/version.py", "exec"))
+REQUIREMENTS = ["requests", "lxml", "future-fstrings"]
 
 
 # A utility function to read the README file into the long_description field.
@@ -26,28 +28,29 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-setup(name=__pkgname__,
-      version=__version__,
-      author='Parag Baxi',
-      author_email='parag.baxi@gmail.com',
-      description='QualysGuard(R) Qualys API Package',
-      license='BSD-new',
-      keywords='Qualys QualysGuard API helper network security',
-      url='https://github.com/paragbaxi/qualysapi',
-      package_dir={'': '.'},
-      packages=['qualysapi', ],
-      # package_data={'qualysapi':['LICENSE']},
-      # scripts=['src/scripts/qhostinfo.py', 'src/scripts/qscanhist.py', 'src/scripts/qreports.py'],
-      long_description=read('README.md'),
-      classifiers=[
-          'Development Status :: 5 - Production/Stable',
-          'Topic :: Utilities',
-          'License :: OSI Approved :: Apache Software License',
-          'Intended Audience :: Developers',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-      ],
+setup(
+    name=__pkgname__,
+    version=__version__,
+    author="Parag Baxi",
+    author_email="parag.baxi@gmail.com",
+    description="QualysGuard(R) Qualys API Package",
+    license="BSD-new",
+    keywords="Qualys QualysGuard API helper network security",
+    url="https://github.com/paragbaxi/qualysapi",
+    package_dir={"": "."},
+    packages=["qualysapi"],
+    # package_data={'qualysapi':['LICENSE']},
+    # scripts=['src/scripts/qhostinfo.py', 'src/scripts/qscanhist.py', 'src/scripts/qreports.py'],
+    long_description=read("README.md"),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: Utilities",
+        "License :: OSI Approved :: Apache Software License",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+    ],
     install_requires=REQUIREMENTS,
-     )
+)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ __license__ = 'BSD-new'
 __pkgname__ = None
 __version__ = None
 exec(compile(open('qualysapi/version.py').read(), 'qualysapi/version.py', 'exec'))
+REQUIREMENTS = ["requests", "lxml"]
 
 
 # A utility function to read the README file into the long_description field.
@@ -51,4 +52,5 @@ setup(name=__pkgname__,
       install_requires=[
           'requests',
       ],
+    install_requires=REQUIREMENTS,
      )

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 """
 context.py
 ~~~~~~~~~~

--- a/tests/context.py
+++ b/tests/context.py
@@ -14,7 +14,7 @@ sys.path.insert(
 print("USING context.py")
 try:
     import qualysapi
-except ModuleNotFoundError as E:
+except ImportError as E:
     print(E)
 
 

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+context.py
+~~~~~~~~~~
+Access main module from tests folder
+"""
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../qualysapi"))
+)
+
+print("USING context.py")
+try:
+    import qualysapi
+except ModuleNotFoundError as E:
+    print(E)
+
+
+if __name__ == "__main__":
+    print(os.path.abspath(os.path.join(os.path.dirname(__file__), "../qualysapi")))
+    print(__doc__)
+    print("\tMODULES")
+    print(qualysapi.__doc__)

--- a/tests/test_config.ini
+++ b/tests/test_config.ini
@@ -1,0 +1,23 @@
+; Note, it should be possible to omit any of these entries.
+
+[info]
+hostname = qualysapi.serviceprovider.com
+username = jerry
+password = I<3Elaine
+
+# Set the maximum number of retries each connection should attempt. Note, this applies only to failed connections and timeouts, never to requests where the server returns a response.
+max_retries = 1
+
+[proxy]
+; This section is optional. Leave it out if you're not using a proxy.
+; You can use environmental variables as well: http://www.python-requests.org/en/latest/user/advanced/#proxies
+
+; proxy_protocol set to https, if not specified.
+proxy_url = proxy.mycorp.com
+
+; proxy_port will override any port specified in proxy_url
+proxy_port = 8080
+
+; proxy authentication
+proxy_username = kramer
+proxy_password = giddy up!

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -17,7 +17,6 @@ PKG_ROOT = pathlib.Path(TEST_ROOT.parent).resolve()
 ROOT = pathlib.Path(PKG_ROOT.parent).resolve()
 
 
-@pytest.mark.xfail()
 def test_qualysapi_context_import():
     from context import qualysapi
 
@@ -26,9 +25,11 @@ def test_qualysapi_regular_import():
     import qualysapi
 
 
-# @pytest.mark.parametrize("pkg", ["lxml", "requests"])
-# def test_pkgs_not_required(pkg):
-#     pass
+def test_for_fire():
+    from context import qualysapi
+
+    conf_file = TEST_ROOT.joinpath("test_config.ini")
+    qualysapi.connect(config_file=conf_file)
 
 
 if __name__ == "__main__":

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -28,7 +28,7 @@ def test_qualysapi_regular_import():
 def test_for_fire():
     from context import qualysapi
 
-    conf_file = TEST_ROOT.joinpath("test_config.ini")
+    conf_file = str(TEST_ROOT.joinpath("test_config.ini"))
     qualysapi.connect(config_file=conf_file)
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from sys import version_info
+import importlib
+
+PYTHON_VER = (version_info.major, version_info.minor)
+
+if PYTHON_VER == (2, 7):
+    import pathlib2 as pathlib
+else:
+    import pathlib
+
+import pytest
+
+HERE = pathlib.Path(__file__)
+TEST_ROOT = pathlib.Path(HERE.parent).resolve()
+PKG_ROOT = pathlib.Path(TEST_ROOT.parent).resolve()
+ROOT = pathlib.Path(PKG_ROOT.parent).resolve()
+
+
+def test_qualysapi_context_import():
+    from context import qualysapi
+
+
+def test_qualysapi_regular_import():
+    import qualysapi
+
+
+# @pytest.mark.parametrize("pkg", ["lxml", "requests"])
+# def test_pkgs_not_required(pkg):
+#     pass
+
+
+if __name__ == "__main__":
+    pytest.main(
+        args=[
+            "-vv",
+            "--cov-report",
+            "term",
+            "--cov-report",
+            "xml",
+            "--cov=qualysapi",
+            "tests/",
+        ]
+    )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 from sys import version_info
 import importlib
 
@@ -17,6 +17,7 @@ PKG_ROOT = pathlib.Path(TEST_ROOT.parent).resolve()
 ROOT = pathlib.Path(PKG_ROOT.parent).resolve()
 
 
+@pytest.mark.xfail()
 def test_qualysapi_context_import():
     from context import qualysapi
 


### PR DESCRIPTION
## Changes
* added[ `pathlib2`](https://github.com/mcmtroffaes/pathlib2) and [`future-fstrings`](https://github.com/asottile/future-fstrings) to fix python2.7 without reverting use of `f-strings`
* added very minimal pytest smoke test to CI
* use `pip install .` to test package installation works
* added Python3.5 to CI but allow for failure
* update setup.py to now includes all the required packages
```
    "requests",
    "lxml",
    "future-fstrings",
    "pathlib2 ; python_version == '2.7'",
```
