### PR TITLE
Added username and password options to connect function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Usage
 
 Check out the example scripts in the [/examples directory](https://github.com/paragbaxi/qualysapi/blob/master/examples/).
 
+Connect
+-------
+There are currenty three methods of connecting to Qualys APIs
+
+* `qualysapi.connect()` will prompt the user for credentials at runtime.
+* `qualysapi.connect('/path/to/config.ini')` will parse the config file for credentials (see below).
+* `qualysapi.connect(username='username', password='password')` will use the provided credentials. 
+
+
 Example
 -------
 Detailed example found at [qualysapi-example.py](https://github.com/paragbaxi/qualysapi/blob/master/examples/qualysapi-example.py).

--- a/examples/qualysapi-simple-v2-creds.py
+++ b/examples/qualysapi-simple-v2-creds.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+# Use the defusedxml package for all xml parsing. See bandit docs: 
+# https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b405-import-xml-etree
+from defusedxml.ElementTree import fromstring
+from qualysapi import connect
+
+# API url to pull data from. See qualys docs for a list of APIs
+api_url = "/api/2.0/fo/asset/host/"
+
+# Options for API request. See qualys docs for a list of all options
+params = {
+    'action': 'list',
+    'truncation_limit': '10',
+}
+
+# Create a connection object used to pull data from Qualys
+conn = connect(
+    username="<username>", # Qualys Username
+    password="<password>", # Qualys Password
+    hostname="<hostname>", # Optional api host url
+    max_retries="<#>",     # Optional # of retries
+)
+
+# Perform API request
+resp = conn.request(api_url, params)
+print(resp) # Raw text response from Qualys
+
+# Parse the response string and convert to an xml object
+xml = fromstring(resp.encode('utf-8'))
+for host in xml.iter(tag='HOST'):
+    id = host.find('./ID').text
+    ip = host.find('./DNS').text
+    print(id + ": " + ip)

--- a/qualysapi/util.py
+++ b/qualysapi/util.py
@@ -15,16 +15,26 @@ __license__ = 'Apache License 2.0'
 logger = logging.getLogger(__name__)
 
 
-def connect(config_file=qcs.default_filename, section='info', remember_me=False, remember_me_always=False):
+# NOTE: Possibly switch to multimethod for clarity
+def connect(config_file=qcs.default_filename, section='info', remember_me=False, remember_me_always=False,
+            username=None, password=None, hostname="qualysapi.qualys.com", max_retries="3"):
     """ Return a QGAPIConnect object for v1 API pulling settings from config
     file.
     """
-    # Retrieve login credentials.
-    conf = qcconf.QualysConnectConfig(filename=config_file, section=section, remember_me=remember_me,
-                                      remember_me_always=remember_me_always)
-    connect = qcconn.QGConnector(conf.get_auth(),
-                                 conf.get_hostname(),
-                                 conf.proxies,
-                                 conf.max_retries)
+    # Use function parameter login credentials.
+    if username and password:
+        connect = qcconn.QGConnector(auth=(username, password),
+                                     server=hostname,
+                                     max_retries=max_retries)
+
+    # Retrieve login credentials from config file.
+    else:
+        conf = qcconf.QualysConnectConfig(filename=config_file, section=section, remember_me=remember_me,
+                                          remember_me_always=remember_me_always)
+        connect = qcconn.QGConnector(conf.get_auth(),
+                                     conf.get_hostname(),
+                                     conf.proxies,
+                                     conf.max_retries)
+
     logger.info("Finished building connector.")
     return connect


### PR DESCRIPTION
Users can now optionally specify a username and password, hostname and max retries in the connect function instead of having to rely solely on a config file. Changes are backwards comparable with previous versions and still default to using config files. Username and other added optional variables need to be specified by name.

Also added a new example file that uses python 3 and a brief note about the change in the readme. 