### PR TITLE
fix special characters in password

### DIFF
--- a/qualysapi/util.py
+++ b/qualysapi/util.py
@@ -5,6 +5,8 @@ import qualysapi.config as qcconf
 import qualysapi.connector as qcconn
 import qualysapi.settings as qcs
 
+from urllib.parse import quote_plus
+
 
 __author__ = "Parag Baxi <parag.baxi@gmail.com> & Colin Bell <colin.bell@uwaterloo.ca>"
 __copyright__ = "Copyright 2011-2013, Parag Baxi & University of Waterloo"
@@ -32,7 +34,7 @@ def connect(
     # Use function parameter login credentials.
     if username and password:
         connect = qcconn.QGConnector(
-            auth=(username, password), server=hostname, max_retries=max_retries, proxies=proxies
+            auth=(username, quote_plus(password)), server=hostname, max_retries=max_retries, proxies=proxies
         )
 
     # Retrieve login credentials from config file.


### PR DESCRIPTION
Applications using Qualys API module returns error when it has special characters like % or + etc, urllib.parse.quote_plus is a fix for such issues