### PR TITLE
removing useless prints

### DIFF
--- a/qualysapi/config.py
+++ b/qualysapi/config.py
@@ -88,7 +88,6 @@ class QualysConnectConfig:
                 self.max_retries = int(self.max_retries)
             except Exception:
                 logger.error("Value max_retries must be an integer.")
-                print("Value max_retries must be an integer.")
                 exit(1)
             self._cfgparse.set(self._section, "max_retries", str(self.max_retries))
         self.max_retries = int(self.max_retries)
@@ -102,7 +101,6 @@ class QualysConnectConfig:
                 self.report_template_id = int(self.report_template_id)
             except Exception:
                 logger.error("Report Template ID Must be set and be an integer")
-                print("Value template ID must be an integer.")
                 exit(1)
             self._cfgparse.set(self._section, "template_id", str(self.report_template_id))
         self.report_template_id = int(self.report_template_id)

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -551,7 +551,6 @@ class QGConnector(api_actions.QGActions):
                     logger.critical("Retry #%d", retries)
                 else:
                     # Ran out of retries. Let user know.
-                    print("Alert! Ran out of concurrent_scans_retries!")
                     logger.critical("Alert! Ran out of concurrent_scans_retries!")
                     return False
         # Check to see if there was an error.
@@ -559,19 +558,14 @@ class QGConnector(api_actions.QGActions):
             request.raise_for_status()
         except requests.HTTPError as e:
             # Error
-            print("Error! Received a 4XX client error or 5XX server error response.")
-            print("Content = \n", response)
+            logger.error("Error! Received a 4XX client error or 5XX server error response.")
             logger.error("Content = \n%s", response)
-            print("Headers = \n", request.headers)
             logger.error("Headers = \n%s", str(request.headers))
             request.raise_for_status()
         if '<RETURN status="FAILED" number="2007">' in response:
-            print(
-                "Error! Your IP address is not in the list of secure IPs. Manager must include this IP (QualysGuard VM > Users > Security)."
-            )
-            print("Content = \n", response)
+            logger.error("Error! Your IP address is not in the list of secure IPs." \
+                         +" Manager must include this IP (QualysGuard VM > Users > Security).")
             logger.error("Content = \n%s", response)
-            print("Headers = \n", request.headers)
             logger.error("Headers = \n%s", str(request.headers))
             return False
         return response


### PR DESCRIPTION
qualysapi always prints output during catching an error. It's quite noisy and when someone tries to catch and handle an exception qualysapi prints error text to stdout.
Fix for https://github.com/paragbaxi/qualysapi/issues/97