### PR TITLE
fix accept content type value for xml format

### DIFF
--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -261,7 +261,7 @@ class QGConnector(api_actions.QGActions):
         if api_version in ("am", "was", "am2"):
             if self.data_exchange_format == 'xml':
                 headers["Content-type"] = "text/xml"
-                headers["Accept"] = "text/xml"
+                headers["Accept"] = "application/xml"
             if self.data_exchange_format == 'json':
                 headers["Content-type"] = "application/json"
                 headers["Accept"] = "application/json"


### PR DESCRIPTION
text/xml does not work in production. accepted values are "\*/\*" (in previous qualys api versions) or "application/xml" per documentation
note this is different from the content-type value , which is "text/xml"