### PR TITLE
Verification on https protocol when computing the base url of an api call

### DIFF
--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -118,22 +118,25 @@ class QGConnector(api_actions.QGActions):
         """ Return base API url string for the QualysGuard api_version and server.
 
         """
+        if "https://" not in self.server:
+            url = f"https://{self.server}"
+
         # Set base url depending on API version.
         if api_version == 1:
             # QualysGuard API v1 url.
-            url = f"https://{self.server}/msp/"
+            url += f"/msp/"
         elif api_version == 2:
             # QualysGuard API v2 url.
-            url = f"https://{self.server}/"
+            url += f"/"
         elif api_version == "was":
             # QualysGuard REST v3 API url (Portal API).
-            url = f"https://{self.server}/qps/rest/3.0/"
+            url += f"/qps/rest/3.0/"
         elif api_version == "am":
             # QualysGuard REST v2 API url (Portal API).
-            url = f"https://{self.server}/qps/rest/2.0/"
+            url += f"/qps/rest/2.0/"
         elif api_version == "am2":
             # QualysGuard REST v2 API url (Portal API).
-            url = f"https://{self.server}/qps/rest/2.0/"
+            url += f"/qps/rest/2.0/"
         else:
             raise Exception(f"Unknown QualysGuard API Version Number {api_version}")
         logger.debug("Base url =\n%s", url)

--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -118,29 +118,24 @@ class QGConnector(api_actions.QGActions):
         """ Return base API url string for the QualysGuard api_version and server.
 
         """
-        if "https://" not in self.server:
-            url = f"https://{self.server}"
+        url = f"https://{self.server}" if "https://" not in self.server else self.server
 
-        # Set base url depending on API version.
-        if api_version == 1:
-            # QualysGuard API v1 url.
-            url += f"/msp/"
-        elif api_version == 2:
-            # QualysGuard API v2 url.
-            url += f"/"
-        elif api_version == "was":
-            # QualysGuard REST v3 API url (Portal API).
-            url += f"/qps/rest/3.0/"
-        elif api_version == "am":
-            # QualysGuard REST v2 API url (Portal API).
-            url += f"/qps/rest/2.0/"
-        elif api_version == "am2":
-            # QualysGuard REST v2 API url (Portal API).
-            url += f"/qps/rest/2.0/"
-        else:
+        paths = {
+            1: "/msp/",  # QualysGuard API v1 url.
+            2: "/",  # QualysGuard API v2 url.
+            "was": "/qps/rest/3.0/",  # QualysGuard REST v3 API url (Portal API).  
+            "am": "/qps/rest/2.0/",  # QualysGuard REST v2 API url (Portal API).
+            "am2": "/qps/rest/2.0/",  # QualysGuard REST v2 API url (Portal API).
+        }
+
+        computed_path = paths.get(api_version)
+
+        if computed_path is None:
             raise Exception(f"Unknown QualysGuard API Version Number {api_version}")
+        
         logger.debug("Base url =\n%s", url)
-        return url
+        return url + computed_path
+
 
     def format_http_method(self, api_version, api_call, data):
         """ Return QualysGuard API http method, with POST preferred..


### PR DESCRIPTION
A lot of people make mistakes when providing the "server" parameter when creating a QGConnector by giving the protocol within the parameter resulting a malformed URL.

We added a verification to ensure that the protocol is not put twice in the computed URL.
We also refactored the function to use a dict instead of a list of if statements.